### PR TITLE
fix: update OAuth redirect URLs to use environment variable

### DIFF
--- a/src/app/oauth/route.ts
+++ b/src/app/oauth/route.ts
@@ -21,5 +21,5 @@ export async function GET(request: NextRequest) {
     secure: true,
   });
 
-  return NextResponse.redirect(`${request.nextUrl.origin}/`);
+  return NextResponse.redirect(`${process.env.NEXT_PUBLIC_APP_URL}/`);
 }

--- a/src/lib/oauth.ts
+++ b/src/lib/oauth.ts
@@ -2,18 +2,15 @@
 
 import { createAdminClient } from "@/lib/appwrite";
 import { redirect } from "next/navigation";
-import { headers } from "next/headers";
 import { OAuthProvider } from "node-appwrite";
 
 export async function signUpWithGithub() {
   const { account } = await createAdminClient();
 
-  const origin = (await headers()).get("origin");
-
   const redirectUrl = await account.createOAuth2Token(
     OAuthProvider.Github,
-    `${origin}/oauth`,
-    `${origin}/sign-up`
+    `${process.env.NEXT_PUBLIC_APP_URL}/oauth`,
+    `${process.env.NEXT_PUBLIC_APP_URL}/sign-up`
   );
 
   return redirect(redirectUrl);


### PR DESCRIPTION
- Changed redirect URLs in the OAuth route and GitHub sign-up function to utilize NEXT_PUBLIC_APP_URL for consistency and flexibility in deployment.